### PR TITLE
Change small routing(name) error

### DIFF
--- a/themes/diplohack-brussels/pages/blogcategory.htm
+++ b/themes/diplohack-brussels/pages/blogcategory.htm
@@ -1,5 +1,5 @@
 title = "Blog Category"
-url = "/nieuws/category/:slug/:page?"
+url = "/blog/category/:slug/:page?"
 layout = "default"
 is_hidden = 0
 


### PR DESCRIPTION
URL route for blog categories was still on "nieuws", while other urls
were already set to blog instead. Changed this here.
