### PR TITLE
changes to timeline block

### DIFF
--- a/themes/diplohack-brussels/pages/home.htm
+++ b/themes/diplohack-brussels/pages/home.htm
@@ -201,9 +201,9 @@ postPage = "nieuws/post"
                     <div class="cd-timeline-content">
                         <h2 class="text-green">EU Datad(r)ive Webinar</h2>
                         <p>
-                            Join us during our online datadive webinar and get to a crash course of the most interesting transparency datasets in all of the EU institutions. Several data experts will explain which datasets are available and how they can be used. This webinar is open to everyone, even data re-users who are not attending one of the Diplohack events.
+                            Read about our online datadive webinar and get to a crash course of the most interesting transparency datasets in all of the EU institutions. Several data experts have explained which datasets are available and how they can be used. Including video. Also accesible for data-reusers not attending the hackathon.
                         </p>
-                        <a href="http://datadrive.eventbrite.nl" target="blank" class="cd-read-more">Sign up</a>
+                        <a href="http://diplohack.brussels/blogpost/diplohack-datadrive-webinar-summary" target="blank" class="cd-read-more">Read our blog post</a>
 
                         <span class="cd-date">15 April </span>
                     </div> <!-- cd-timeline-content -->


### PR DESCRIPTION
First block was still reading as if datadrive is still going to happen
while it already happened, changed it to the past tense and link to the
blog.
